### PR TITLE
fix: Remove trailing slash from the superset domain passed if there is one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@preset-sdk/embedded",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "UNLICENSED",
       "dependencies": {
         "@superset-ui/switchboard": "^0.18.26-0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@preset-sdk/embedded",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@preset-sdk/embedded",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Frontend SDK for embedding Preset data analytics into your own application",
   "access": "public",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,10 @@ export async function embedDashboard({
   // Polyfill replaceChildren
   applyReplaceChildrenPolyfill()
 
+  if (supersetDomain.endsWith("/")) {
+    supersetDomain = supersetDomain.slice(0, -1);
+  }
+
   function calculateConfig() {
     let configNumber = 0
     if(dashboardUiConfig) {


### PR DESCRIPTION
Without this change, passing a URL with a trailing slash would result in the dashboard not loading with no error.