### PR TITLE
Allow custom URL params in embedded dashboard like in regular dashboard URLs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,9 +99,9 @@ export async function embedDashboard({
       const iframe = document.createElement('iframe');
       const dashboardConfig = dashboardUiConfig ? `uiConfig=${calculateConfig()}` : ""
       const filterConfig = dashboardUiConfig?.filters || {}
-      const filterConfigKeys = Object.entries(filterConfig).filter(
-        ([uiKey]) => DASHBOARD_UI_FILTER_CONFIG_URL_PARAM_KEY[uiKey],
-      );
+      const filterConfigKeys = Object.entries(filterConfig).map(
+        ([uiKey, uiValue]) => [DASHBOARD_UI_FILTER_CONFIG_URL_PARAM_KEY[uiKey], uiValue]
+      ).filter(([key]) => key) as [string, unknown][];
       const filterConfigUrlParams =
         filterConfigKeys.length > 0 ? entriesToQS(filterConfigKeys) : null;
 


### PR DESCRIPTION
In today's logic, it's possible to pass any desired URL parameters and read/use them with jinja. apparently, **that is not the case with the SDK**, hence this PR

Main changes -

1. Type Fix - commit 596f3f7 has a missing type for the `setInterval`.
2. Fix - there was an issue with the querystring question mark `?` that's added only if `dashboardConfig` is set. meaning that in cases of just `filterConfigUrlParams` exist there's no question mark at all.
3. Add - Now's possible to add custom `urlParams` and it works out of the box with jinja.