### PR TITLE
chore: Bump switchboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@preset-sdk/embedded",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@preset-sdk/embedded",
-      "version": "0.1.9",
-      "license": "UNLICENSED",
+      "version": "0.1.10",
+      "license": "Preset Cloud Website Dashboard SDK License Agreement",
       "dependencies": {
-        "@superset-ui/switchboard": "^0.18.26-0"
+        "@superset-ui/switchboard": "^0.20.3"
       },
       "devDependencies": {
         "@babel/cli": "^7.16.8",
@@ -2402,9 +2402,9 @@
       }
     },
     "node_modules/@superset-ui/switchboard": {
-      "version": "0.18.26-0",
-      "resolved": "https://registry.npmjs.org/@superset-ui/switchboard/-/switchboard-0.18.26-0.tgz",
-      "integrity": "sha512-MYvigrspA0EgNU6tA9UrsXcrUYid9YktsbIPx/D4Xd5cWWrJrJl303imQ/SIZbC25faJCd2gL30ORll60Yz3Ww=="
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@superset-ui/switchboard/-/switchboard-0.20.3.tgz",
+      "integrity": "sha512-qEMXFwdRLfXug4gXXdBEGpFtBWZoxdZkCJLBVxj1IR8cQvSqjkWAQOzSSYYdcIeREWqi8iP+iK6apNV1ZQCKcA=="
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -9881,9 +9881,9 @@
       }
     },
     "@superset-ui/switchboard": {
-      "version": "0.18.26-0",
-      "resolved": "https://registry.npmjs.org/@superset-ui/switchboard/-/switchboard-0.18.26-0.tgz",
-      "integrity": "sha512-MYvigrspA0EgNU6tA9UrsXcrUYid9YktsbIPx/D4Xd5cWWrJrJl303imQ/SIZbC25faJCd2gL30ORll60Yz3Ww=="
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@superset-ui/switchboard/-/switchboard-0.20.3.tgz",
+      "integrity": "sha512-qEMXFwdRLfXug4gXXdBEGpFtBWZoxdZkCJLBVxj1IR8cQvSqjkWAQOzSSYYdcIeREWqi8iP+iK6apNV1ZQCKcA=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "last 3 edge versions"
   ],
   "dependencies": {
-    "@superset-ui/switchboard": "^0.18.26-0"
+    "@superset-ui/switchboard": "^0.20.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.8",


### PR DESCRIPTION
This PR bumps the [@superset-ui/switchboard package](https://www.npmjs.com/package/@superset-ui/switchboard) to the latest version.