### PR TITLE
feat: Emit data mask and other missing functions from OSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@preset-sdk/embedded",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Frontend SDK for embedding Preset data analytics into your own application",
   "access": "public",
   "keywords": [


### PR DESCRIPTION
This PR implements the latest changes from OSS (https://github.com/apache/superset/pull/32997 and https://github.com/apache/superset/pull/31331) and some older functions that were also missing - getDashboardPermalink, getActiveTabs