### PR TITLE
chore: Add more info to release failures

### DIFF
--- a/release-if-necessary.js
+++ b/release-if-necessary.js
@@ -32,6 +32,7 @@ function logError(...args) {
       log(`published ${version} to npm`);
     } catch (err) {
       console.error(String(err.stdout));
+      console.error(String(err.stderr));
       logError('Encountered an error, details should be above');
       process.exitCode = 1;
     }


### PR DESCRIPTION
Previous PR to release a new version failed, so this PR adds more logging so we can further debug the issue.