### PR TITLE
chore: Bump node, actions and set up Trusted Publishers for npm

### DIFF
--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -8,16 +8,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           registry-url: 'https://registry.npmjs.org'
       - name: release
         run: |
           npm ci
-          npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
           npm run ci:release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: 'https://registry.npmjs.org'
       - name: release
         run: |

--- a/.github/workflows/embedded-sdk-test.yml
+++ b/.github/workflows/embedded-sdk-test.yml
@@ -9,10 +9,10 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm test

--- a/.github/workflows/embedded-sdk-test.yml
+++ b/.github/workflows/embedded-sdk-test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
- Bumping `node-version` to `20` to align with Preset Cloud (Shell)
- Bumping actions to `v4` to avoid deprecation warnings
- Deprecate NPM token auth and implement [Trusted Publishers](https://docs.npmjs.com/trusted-publishers)