### PR TITLE
chore: Bump npm to support Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           node-version: "22"
           registry-url: 'https://registry.npmjs.org'
+      - name: upgrade npm for Trusted Publishers support
+        run: npm install -g npm@latest
       - name: release
         run: |
           npm ci


### PR DESCRIPTION
The action to publish the package is failing: https://github.com/preset-io/frontend-sdk/actions/runs/26058527248/job/76612548603

According [to the docs](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publishing-to-npm-with-trusted-publisher-oidc), this publishing method requires `npm >=11.5.1`, which is not installed by default with `node_version:22`.

This PR attempts to fix the issue by manually bumping `npm`.